### PR TITLE
Comment back in Pull Request when the run is done

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,8 +2,15 @@ FROM quay.io/operator-framework/ansible-operator:v1.25.0
 
 USER root
 
-RUN yum install -y git
-RUN yum clean all
+RUN dnf install -y git
+
+# Github CLI
+
+RUN dnf install -y 'dnf-command(config-manager)'
+RUN dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+RUN dnf install -y gh
+
+RUN dnf clean all
 COPY ipa.crt /etc/pki/ca-trust/source/anchors/
 RUN update-ca-trust
 

--- a/readme.adoc
+++ b/readme.adoc
@@ -196,6 +196,10 @@ spec:
     image: image-registry.apps-dev.open.redhat.com/agnosticd/ee-{{ merged_vars.__meta__.deployer.virtualenv | default('ansible2.9-python3.6-2021-11-30') }}
     private: true
 ----
+* Github integration
+** `spec.github_token` -- GitHub access token.
+** `spec.github_comment_success` and `spec.github_comment_failure` -- jinaj2 content of the comments.
+** `spec.catalog_url` -- URL of the catalog to pass in GitHub comments.
 
 == Troubleshooting
 

--- a/roles/agnosticv/defaults/main.yml
+++ b/roles/agnosticv/defaults/main.yml
@@ -123,3 +123,16 @@ execution_environment: >-
 
 # Override __meta__.deployer.execution_environment
 default_execution_environment: {}
+
+
+# GitHub integration
+github_comment_success: |
+  AgnosticV operator update for revision {{ r_repo.after }} finished successfully.
+  The change from this PR should be included.
+
+  You can see the updated catalog at {{ catalog_url }}
+
+github_comment_failure: |
+  AgnosticV operator failed to update for revision {{ r_repo.after }}.
+
+  Check the logs or loki.

--- a/roles/agnosticv/defaults/main.yml
+++ b/roles/agnosticv/defaults/main.yml
@@ -136,3 +136,7 @@ github_comment_failure: |
   AgnosticV operator failed to update for revision {{ r_repo.after }}.
 
   Check the logs or loki.
+
+# quick_start=false  Process all catalog items at startup
+# quick_start=true   Wait for the next change
+quick_start: false

--- a/roles/agnosticv/defaults/main.yml
+++ b/roles/agnosticv/defaults/main.yml
@@ -127,7 +127,7 @@ default_execution_environment: {}
 
 # GitHub integration
 github_comment_success: |
-  AgnosticV operator update for revision {{ r_repo.after }} finished successfully.
+  Update by AgnosticV operator for revision {{ r_repo.after }} finished successfully.
   The change from this PR should be included.
 
   You can see the updated catalog at {{ catalog_url }}

--- a/roles/agnosticv/tasks/main.yml
+++ b/roles/agnosticv/tasks/main.yml
@@ -118,7 +118,9 @@
       # Fail safe: if the change list is too long (> 1000), just process all.
       command: >-
         {{ agnosticv_client_path }} --list --has __meta__.catalog
-        {%- if changed | length > 0 and changed | length < 1000 %}
+        {%- if changed | length == 0 and quick_start %}
+        --related /dev/null
+        {%- elif changed | length > 0 and changed | length < 1000 %}
         --related {{ changed | join(' --or-related ') }}
         {%- endif %}
       args:

--- a/roles/agnosticv/tasks/main.yml
+++ b/roles/agnosticv/tasks/main.yml
@@ -193,6 +193,7 @@
         and catalog_url is defined
         and r_repo.changed
         and r_repo.before
+        and r_repo.after
       include_tasks: report_github.yml
 
 - name: Fail if any catalog item failed

--- a/roles/agnosticv/tasks/main.yml
+++ b/roles/agnosticv/tasks/main.yml
@@ -188,7 +188,7 @@
     - name: Report to Github Pull Requests
       when: >-
         github_token is defined
-        and rhpds_catalog_url is defined
+        and catalog_url is defined
         and r_repo.changed
         and r_repo.before
       include_tasks: report_github.yml

--- a/roles/agnosticv/tasks/main.yml
+++ b/roles/agnosticv/tasks/main.yml
@@ -185,6 +185,14 @@
         catalog_item: "{{ c_i.split('/')[-2] }}"
         stage: "{{ c_i.split('/')[-1] | regex_replace('\\.ya?ml$', '') }}"
 
+    - name: Report to Github Pull Requests
+      when: >-
+        github_token is defined
+        and rhpds_catalog_url is defined
+        and r_repo.changed
+        and r_repo.before
+      include_tasks: report_github.yml
+
 - name: Fail if any catalog item failed
   when: flag_fail
   fail:

--- a/roles/agnosticv/tasks/report_github.yml
+++ b/roles/agnosticv/tasks/report_github.yml
@@ -1,7 +1,4 @@
 ---
-- debug:
-    var: r_repo
-
 - name: Get list of auto-merged PRs
   shell: >-
     git log --pretty=reference
@@ -15,9 +12,6 @@
     chdir: "{{ agnosticv_path }}"
   register: r_prs
 
-- debug:
-    var: r_prs
-
 - name: Comment back in PRs
   when: r_prs.stdout_lines | length > 0
   # Don't rely on github API, ignore any error
@@ -30,11 +24,10 @@
   loop_control:
     pause: 2
 
-  debug:
-    msg: |-
-      {% if flag_fail | default(false) %}
-        gh pr comment {{ item }} --body {{ github_comment_failure | quote }}
-      {% else %}
-        gh pr comment {{ item }} --body {{ github_comment_success | quote }}
-        gh pr edit {{ item }} --add-label integration
-      {% endif %}
+  shell: |-
+    {% if flag_fail | default(false) %}
+      gh pr comment {{ item }} --body {{ github_comment_failure | quote }}
+    {% else %}
+      gh pr comment {{ item }} --body {{ github_comment_success | quote }}
+      gh pr edit {{ item }} --add-label integration
+    {% endif %}

--- a/roles/agnosticv/tasks/report_github.yml
+++ b/roles/agnosticv/tasks/report_github.yml
@@ -14,6 +14,8 @@
 
 - name: Comment back in PRs
   when: r_prs.stdout_lines | length > 0
+  # Don't rely on github API, ignore any error
+  ignore_errors: true
   environment:
     GITHUB_TOKEN: "{{ github_token }}"
   args:

--- a/roles/agnosticv/tasks/report_github.yml
+++ b/roles/agnosticv/tasks/report_github.yml
@@ -20,13 +20,12 @@
     GITHUB_TOKEN: "{{ github_token }}"
   args:
     chdir: "{{ agnosticv_path }}"
+  loop: "{{ r_prs.stdout_lines }}"
 
   shell: |-
-    for PR in {{ r_prs.stdout }}; do
-      {% if flag_fail | default(false) %}
-        gh pr comment ${PR} --body {{ github_comment_failure | quote }}
-      {% else %}
-        gh pr comment ${PR} --body {{ github_comment_success | quote }}
-        gh pr edit ${PR} --add-label integration
-      {% endif %}
-    done
+    {% if flag_fail | default(false) %}
+      gh pr comment {{ item }} --body {{ github_comment_failure | quote }}
+    {% else %}
+      gh pr comment {{ item }} --body {{ github_comment_success | quote }}
+      gh pr edit {{ item }} --add-label integration
+    {% endif %}

--- a/roles/agnosticv/tasks/report_github.yml
+++ b/roles/agnosticv/tasks/report_github.yml
@@ -12,6 +12,9 @@
     chdir: "{{ agnosticv_path }}"
   register: r_prs
 
+- debug:
+    var: r_prs
+
 - name: Comment back in PRs
   when: r_prs.stdout_lines | length > 0
   # Don't rely on github API, ignore any error

--- a/roles/agnosticv/tasks/report_github.yml
+++ b/roles/agnosticv/tasks/report_github.yml
@@ -24,6 +24,8 @@
   args:
     chdir: "{{ agnosticv_path }}"
   loop: "{{ r_prs.stdout_lines }}"
+  loop_control:
+    pause: 2
 
   shell: |-
     {% if flag_fail | default(false) %}

--- a/roles/agnosticv/tasks/report_github.yml
+++ b/roles/agnosticv/tasks/report_github.yml
@@ -1,0 +1,29 @@
+---
+- name: Get list of auto-merged PRs
+  shell: >-
+    git log --pretty=reference
+    {{ r_repo.before | quote }} {{ r_repo.after |quote }}
+    | cut -d' ' -f 1 --complement
+    | grep -E '^\(Auto-merge \#'
+    | perl -pe 's/^\(Auto-merge \#(\d+) .*/$1/'
+    | sort
+    | uniq
+  args:
+    chdir: "{{ agnosticv_path }}"
+  register: r_prs
+
+- name: Comment back in PRs
+  when: r_prs.stdout_lines | length > 0
+  environment:
+    GITHUB_TOKEN: "{{ github_token }}"
+  args:
+    chdir: "{{ agnosticv_path }}"
+
+  shell: |-
+    for PR in {{ r_prs.stdout }}; do
+      {% if flag_fail | default(false) %}
+        gh pr comment ${PR} --body {{ github_comment_failure | quote }}
+      {% else %}
+        gh pr comment ${PR} --body {{ github_comment_success | quote }}
+      {% endif %}
+    done

--- a/roles/agnosticv/tasks/report_github.yml
+++ b/roles/agnosticv/tasks/report_github.yml
@@ -27,5 +27,6 @@
         gh pr comment ${PR} --body {{ github_comment_failure | quote }}
       {% else %}
         gh pr comment ${PR} --body {{ github_comment_success | quote }}
+        gh pr edit ${PR} --add-label integration
       {% endif %}
     done

--- a/roles/agnosticv/tasks/report_github.yml
+++ b/roles/agnosticv/tasks/report_github.yml
@@ -12,9 +12,6 @@
     chdir: "{{ agnosticv_path }}"
   register: r_prs
 
-- debug:
-    var: r_prs
-
 - name: Comment back in PRs
   when: r_prs.stdout_lines | length > 0
   # Don't rely on github API, ignore any error
@@ -27,10 +24,11 @@
   loop_control:
     pause: 2
 
-  shell: |-
-    {% if flag_fail | default(false) %}
-      gh pr comment {{ item }} --body {{ github_comment_failure | quote }}
-    {% else %}
-      gh pr comment {{ item }} --body {{ github_comment_success | quote }}
-      gh pr edit {{ item }} --add-label integration
-    {% endif %}
+  debug:
+    msg: |-
+      {% if flag_fail | default(false) %}
+        gh pr comment {{ item }} --body {{ github_comment_failure | quote }}
+      {% else %}
+        gh pr comment {{ item }} --body {{ github_comment_success | quote }}
+        gh pr edit {{ item }} --add-label integration
+      {% endif %}

--- a/roles/agnosticv/tasks/report_github.yml
+++ b/roles/agnosticv/tasks/report_github.yml
@@ -1,4 +1,7 @@
 ---
+- debug:
+    var: r_repo
+
 - name: Get list of auto-merged PRs
   shell: >-
     git log --pretty=reference
@@ -11,6 +14,9 @@
   args:
     chdir: "{{ agnosticv_path }}"
   register: r_prs
+
+- debug:
+    var: r_prs
 
 - name: Comment back in PRs
   when: r_prs.stdout_lines | length > 0

--- a/roles/agnosticv/tasks/report_github.yml
+++ b/roles/agnosticv/tasks/report_github.yml
@@ -5,7 +5,7 @@
 - name: Get list of auto-merged PRs
   shell: >-
     git log --pretty=reference
-    {{ r_repo.before | quote }} {{ r_repo.after |quote }}
+    {{ r_repo.before | quote }}..{{ r_repo.after |quote }}
     | cut -d' ' -f 1 --complement
     | grep -E '^\(Auto-merge \#'
     | perl -pe 's/^\(Auto-merge \#(\d+) .*/$1/'


### PR DESCRIPTION
This change, if applied, adds a feature in agnosticv-operator to report back into all PRs, based on a certain kind of activity in commits.

It gets the list of PRs from the list of new commits using the convention setup in rhpds/agnosticv#7589 : All commits that start with the string `Auto-merge #...`.

We parse only the new commits, so we process the list of PRs only once and should not comment more than once for a change.

We will use that in conjunction with the integration branch.


Also introduce a new variable `quick_start: true|false` (default=false)  to skip updating all catalog items at startup.